### PR TITLE
deps: update golangci-lint to v1.62.2

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-11-12T21:58:17.302584512Z",
-  "version": "1.2.23",
+  "generated_at": "2024-12-03T20:03:52.07289603Z",
+  "version": "1.2.24",
   "files": [
     {
       "path": ".editorconfig"

--- a/.github/workflows/go-lint-test.yml
+++ b/.github/workflows/go-lint-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: giantswarm/install-binary-action@v3.0.0
         with:
           binary: "golangci-lint"
-          version: "1.61.0"
+          version: "1.62.2"
           download_url: "https://github.com/golangci/golangci-lint/releases/download/v${version}/golangci-lint-${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
   # use the fixed version to not introduce new linters unexpectedly
-  golangci-lint-version: 1.61.0
+  golangci-lint-version: 1.62.2
 
 run:
   # golang-ci lint runtime timeout


### PR DESCRIPTION
deps: update golangci-lint to v1.62.2